### PR TITLE
Fixed type declaration

### DIFF
--- a/addons/main/functions/fnc_showDialog.sqf
+++ b/addons/main/functions/fnc_showDialog.sqf
@@ -157,7 +157,7 @@ private _fnc_AddBoolean = {
 };
 
 private _fnc_AddDropDown = {
-    params ["_text", "", ["_tooltip", ""], ["_values", [], []], ["_default", 0, [0]]];
+    params ["_text", "", ["_tooltip", ""], ["_values", [], [[]]], ["_default", 0, [0]]];
     if (isLocalized _tooltip) then {
         _tooltip = localize _tooltip;
     };


### PR DESCRIPTION
This PR is a small fix to the type declaration of `params`.

When an array is passed, its third value is an array of objects representing their types (see example 5 in https://community.bistudio.com/wiki/params). This array was empty, which would represent that no types are allowed. Given that the default is an empty array, I suspect that what we mean is that `_fnc_AddDropDown` expects an object of type array. This PR does this.

Found while analyzing the code with https://marketplace.visualstudio.com/items?itemName=SQF-analyzer.sqf-analyzer
